### PR TITLE
Moving interactions to dynamic components

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,0 +1,8 @@
+import { configure } from '@kadira/storybook';
+
+function loadStories() {
+  require('../src/components/interactions/stories/ReactionsStories.jsx');
+  // require as many stories as you need.
+}
+
+configure(loadStories, module);

--- a/src/components/commentMenu/Block.jsx
+++ b/src/components/commentMenu/Block.jsx
@@ -6,14 +6,14 @@ class Block extends Component {
 
   static propTypes = {
     id:PropTypes.string.isRequired,
-    items:PropTypes.object.isRequired,
+    comments:PropTypes.object.isRequired,
     dispatch:PropTypes.func.isRequired
   }
 
   onBlockClick(e) {
     e.preventDefault();
-    const blockedUser = this.props.items[this.props.id].user;
-    this.props.dispatch(addComponent('stream','BlockFilter',['stream','items'],-100,{blockedUser: blockedUser}));
+    const blockedUser = this.props.comments[this.props.id].user;
+    this.props.dispatch(addComponent('stream','BlockFilter',['stream','comments'],-100,{blockedUser: blockedUser}));
   }
 
   render() {

--- a/src/components/commentMenu/CommentMenuContainer.jsx
+++ b/src/components/commentMenu/CommentMenuContainer.jsx
@@ -17,7 +17,7 @@ import components from './';
   (state) => {
     return {
       config: state.newPlayground.config.commentMenu,
-      items: state.newPlayground.items.comments
+      comments: state.newPlayground.items.comments
     };
   },
   (dispatch) => {
@@ -35,7 +35,8 @@ class CommentMenuContainer extends Component {
 
   static propTypes = {
     id:PropTypes.string.isRequired,
-    config:PropTypes.array.isRequired 
+    config:PropTypes.array.isRequired,
+    comments: PropTypes.object.isRequired
   }
 
   mapComponentFromConfig(config) {

--- a/src/components/comments/DefaultComment.jsx
+++ b/src/components/comments/DefaultComment.jsx
@@ -30,7 +30,7 @@ let defaultStyles =   {
   },
   commentContent: {
     fontSize: '12pt',
-    marginBottom: '20px',
+    marginBottom: '5px',
     width:'95%'
   }
 };

--- a/src/components/interactions/InteractionsContainer.jsx
+++ b/src/components/interactions/InteractionsContainer.jsx
@@ -1,0 +1,69 @@
+import { connect } from 'react-redux';
+import React, {Component, PropTypes} from 'react';
+import components from './';
+
+
+/*
+* Config provides information about how data is rendered
+*  including which component is used, and what the
+*  default style should be.
+*
+* Items includes information about the specific items to be displayed
+*  (e.g. the text of a comment). This is passed to the item listed in config
+*  as props.
+*/
+@connect(
+  (state) => {
+    return {
+      config: state.newPlayground.config.interactions,
+      items: state.newPlayground.items.comments
+    };
+  },
+  (dispatch) => {
+    return {
+      dispatch
+    };
+  }
+)
+
+/*
+* Iterate through each component in config
+* and pass it the appropriate props from items
+*/
+class InteractionsContainer extends Component {
+  mapComponentFromConfig(config) {
+    let Component = components[config.component];
+    let props = {...config.configProps};
+    if (config.propTypes) {
+      for (var i = 0; i < config.propTypes.length; i++) {
+        props[config.propTypes[i]] = this.props.items[this.props.id][config.propTypes[i]];
+      }      
+    }
+    return <Component {...props} dispatch={this.props.dispatch} key={config.component}/>;
+  }
+
+
+  sortConfig(a,b) {
+    if (a.order > b.order) {
+      return 1;
+    }
+    if (a.order < b.order) {
+      return -1;
+    }
+    return 0;
+  }
+
+  render() {
+    const sortedConfig = this.props.config.sort(this.sortConfig);
+    return <div>{
+      sortedConfig.map(this.mapComponentFromConfig.bind(this))
+    }
+    </div>;
+  }
+}
+
+InteractionsContainer.propTypes = {
+  id:PropTypes.string.isRequired
+};
+
+export default InteractionsContainer;

--- a/src/components/interactions/InteractionsContainer.jsx
+++ b/src/components/interactions/InteractionsContainer.jsx
@@ -39,7 +39,10 @@ class InteractionsContainer extends Component {
         props[config.propTypes[i]] = this.props.items[this.props.id][config.propTypes[i]];
       }      
     }
-    return <Component {...props} dispatch={this.props.dispatch} key={config.component}/>;
+    const styles = this.props.styles || defaultStyles;
+    return <div style={styles.interaction}>
+      <Component {...props} dispatch={this.props.dispatch} key={config.component}/>
+    </div>;
   }
 
 
@@ -67,3 +70,10 @@ InteractionsContainer.propTypes = {
 };
 
 export default InteractionsContainer;
+
+const defaultStyles = {
+  interaction: {
+    display:'inline-block',
+    margin:5
+  }
+};

--- a/src/components/interactions/LikeButton.jsx
+++ b/src/components/interactions/LikeButton.jsx
@@ -1,0 +1,40 @@
+import React, {Component, PropTypes} from 'react';
+import {Badge, Icon} from 'react-mdl';
+import {updateItem} from 'playground/PlaygroundActions';
+
+class LikeButton extends Component {
+
+  static propTypes = {
+    id: PropTypes.string.isRequired,
+    likes: PropTypes.number.isRequired,
+    dispatch: PropTypes.func.isRequired
+  }
+
+  incrementLike(e) {
+    e.preventDefault();
+    if (!this.props.liked) {
+      this.props.dispatch(updateItem(this.props.id,'comments','likes',this.props.likes+1));
+      this.props.dispatch(updateItem(this.props.id,'comments','liked',true));
+    }
+  }
+
+  render() {
+    const styles = this.props.styles || defaultStyles;
+    return <div>
+        <Icon onClick={this.incrementLike.bind(this)} style={styles.likeIcon} className='likeIcon' name="thumb_up" />
+        <span style={styles.likeCount} className='likeCount'>{this.props.likes}</span>
+      </div>;
+  }
+}
+
+export default LikeButton;
+
+const defaultStyles = {
+  likeIcon:{
+    fontSize:18,
+    cursor:'pointer'
+  },
+  likeCount:{
+    fontSize:10
+  }
+};

--- a/src/components/interactions/Reactions.jsx
+++ b/src/components/interactions/Reactions.jsx
@@ -27,7 +27,6 @@ export default Reactions;
 const defaultStyles = {
   reactionEmoji: {
     padding:1,
-    border: '1px solid grey',
     borderRadius: 3,
     display: 'inline-block',
     opacity:.75,

--- a/src/components/interactions/Reactions.jsx
+++ b/src/components/interactions/Reactions.jsx
@@ -1,0 +1,36 @@
+import React, {Component, PropTypes} from 'react';
+import ReactEmoji from 'react-emoji';
+
+class Reactions extends Component {
+
+  static propTypes = {
+    reactions: PropTypes.array.isRequired,
+    id: PropTypes.string.isRequired
+  }
+
+  render() {
+    const styles = this.props.styles || defaultStyles;
+    return <div className="reactions">
+      {
+        this.props.reactions.map((reaction) => {
+          return <div className='reactionEmoji' style={styles.reactionEmoji}> 
+              {ReactEmoji.emojify(':' + reaction + ':')}
+            </div>;
+        })
+      }
+    </div>;
+  }
+}
+
+export default Reactions;
+
+const defaultStyles = {
+  reactionEmoji: {
+    padding:1,
+    border: '1px solid grey',
+    borderRadius: 3,
+    display: 'inline-block',
+    opacity:.75,
+    margin: 2
+  }
+};

--- a/src/components/interactions/UpDownVoting.jsx
+++ b/src/components/interactions/UpDownVoting.jsx
@@ -1,0 +1,44 @@
+import React, {Component, PropTypes} from 'react';
+import {Badge, Icon} from 'react-mdl';
+import {updateItem} from 'playground/PlaygroundActions';
+
+class UpDownVoting extends Component {
+
+  static propTypes = {
+    id: PropTypes.string.isRequired,
+    likes: PropTypes.number.isRequired,
+    dispatch: PropTypes.func.isRequired
+  }
+
+  incrementVote(type) {
+    return (e) => {
+      e.preventDefault();
+      if (!this.props.updownvoted) {
+        this.props.dispatch(updateItem(this.props.id,'comments',type,this.props[type]+1));
+        this.props.dispatch(updateItem(this.props.id,'comments','updownvoted',true));
+      }
+    };
+  }
+
+  render() {
+    const styles = this.props.styles || defaultStyles;
+    return <div>
+        <Icon onClick={this.incrementVote('upvotes').bind(this)} style={styles.voteIcon} className='upVoteIcon' name="arrow_upward" />
+        <span style={styles.likeCount} className='likeCount'>{this.props.upvotes}</span>
+        <Icon onClick={this.incrementVote('downvotes').bind(this)} style={styles.voteIcon} className='downVoteIcon' name="arrow_downward" />
+        <span style={styles.likeCount} className='likeCount'>{this.props.downvotes}</span>
+      </div>;
+  }
+}
+
+export default UpDownVoting;
+
+const defaultStyles = {
+  voteIcon:{
+    fontSize:18,
+    cursor:'pointer'
+  },
+  likeCount:{
+    fontSize:10
+  }
+};

--- a/src/components/interactions/index.js
+++ b/src/components/interactions/index.js
@@ -1,5 +1,7 @@
 import Reactions from './Reactions';
+import LikeButton from './LikeButton';
 
 export default {
-  Reactions
+  Reactions,
+  LikeButton
 };

--- a/src/components/interactions/index.js
+++ b/src/components/interactions/index.js
@@ -1,0 +1,5 @@
+import Reactions from './Reactions';
+
+export default {
+  Reactions
+};

--- a/src/components/interactions/index.js
+++ b/src/components/interactions/index.js
@@ -1,7 +1,9 @@
 import Reactions from './Reactions';
 import LikeButton from './LikeButton';
+import UpDownVoting from './UpDownVoting';
 
 export default {
   Reactions,
-  LikeButton
+  LikeButton,
+  UpDownVoting
 };

--- a/src/components/interactions/stories/ReactionsStories.jsx
+++ b/src/components/interactions/stories/ReactionsStories.jsx
@@ -1,0 +1,11 @@
+
+import React from 'react';
+import { storiesOf, action } from '@kadira/storybook';
+
+storiesOf('Button', module)
+  .add('with text', () => (
+    <button onClick={action('clicked')}>My First Button</button>
+  ))
+  .add('with no text', () => (
+    <button></button>
+  ));

--- a/src/components/stream/BlockFilter.jsx
+++ b/src/components/stream/BlockFilter.jsx
@@ -6,7 +6,7 @@ class BlockFilter extends Component {
   static propTypes = {
     blockedUser:PropTypes.string.isRequired,
     stream:PropTypes.array.isRequired,
-    items:PropTypes.array.isRequired,
+    comments:PropTypes.array.isRequired,
     dispatch:PropTypes.func.isRequired
   }
 
@@ -14,7 +14,7 @@ class BlockFilter extends Component {
     this.setState({original:this.props.stream});
     let filteredStream = [];
     for (var i = 0; i < this.props.stream.length; i++) {
-      if (this.props.items.comments[this.props.stream[i]].user != this.props.blockedUser) {
+      if (this.props.comments[this.props.stream[i]].user != this.props.blockedUser) {
         filteredStream.push(this.props.stream[i]);
       }
     }
@@ -26,7 +26,6 @@ class BlockFilter extends Component {
   }
 
   render() {
-    console.log("Rendering blockfilter")
     return null;
   }
 }

--- a/src/components/stream/CommentStream.jsx
+++ b/src/components/stream/CommentStream.jsx
@@ -2,6 +2,7 @@ import React, {Component, PropTypes} from 'react';
 import Comment from '../comments/CommentContainer';
 import Author from '../authors/AuthorContainer';
 import Profile from '../authorProfile/AuthorProfileContainer';
+import Interactions from '../interactions/InteractionsContainer';
 import {updateItem} from 'playground/PlaygroundActions';
 
 class CommentStream extends Component {
@@ -32,6 +33,8 @@ class CommentStream extends Component {
               </div>
               <Profile commentId={id}/>
               <Comment id={id} />
+              <Interactions id={id}/>
+              <hr className="commentDivider" style={styles.commentDivider}/>
             </div>;
           })
         }
@@ -46,6 +49,9 @@ let defaultStyles = {
     fontStyle: 'italic',
     fontSize: '11pt',
     color: '#888'
+  },
+  commentDivider:{
+    marginBottom:20
   }
 };
 

--- a/src/components/stream/StaffFilter.jsx
+++ b/src/components/stream/StaffFilter.jsx
@@ -4,7 +4,7 @@ import {setStream} from '../../playground/PlaygroundActions';
 class StaffFilter extends Component {
 
   static propTypes = {
-    items:PropTypes.object.isRequired,
+    comments:PropTypes.object.isRequired,
     stream:PropTypes.array.isRequired,
     dispatch:PropTypes.func.isRequired
   }
@@ -13,7 +13,7 @@ class StaffFilter extends Component {
     this.setState({original:this.props.stream});
     let filteredStream = [];
     for (var i = 0; i < this.props.stream.length; i++) {
-      if (this.props.items.comments[this.props.stream[i]].staffPick) {
+      if (this.props.comments[this.props.stream[i]].staffPick) {
         filteredStream.push(this.props.stream[i]);
       }
     }

--- a/src/components/stream/StreamTabs.jsx
+++ b/src/components/stream/StreamTabs.jsx
@@ -10,7 +10,7 @@ class StreamTabs extends Component {
   }
 
   onStaffClick() {
-    this.props.dispatch(updateComponent('stream','StaffFilter',['stream','items']));
+    this.props.dispatch(updateComponent('stream','StaffFilter',['stream','comments']));
     this.props.dispatch(updateComponent('stream','StreamTabs',null,null,{activeTab:'staff'}));
   }
 

--- a/src/components/stream/UpDownVoteOrderFilter.jsx
+++ b/src/components/stream/UpDownVoteOrderFilter.jsx
@@ -1,0 +1,32 @@
+import React, {Component, PropTypes} from 'react';
+import {setStream} from '../../playground/PlaygroundActions';
+
+class UpDownVoteOrderFilter extends Component {
+
+  static propTypes = {
+    comments:PropTypes.object.isRequired,
+    stream:PropTypes.array.isRequired,
+    dispatch:PropTypes.func.isRequired
+  }
+
+  componentDidMount() {
+    this.setState({original:this.props.stream});
+    let reorderedStream = this.props.stream.slice();
+    reorderedStream.sort((a,b) => {
+      let c1 = this.props.comments[a];
+      let c2 = this.props.comments[b];
+      return (c2.upvotes - c2.downvotes) - (c1.upvotes - c1.downvotes);
+    });
+    this.props.dispatch(setStream(reorderedStream));
+  }
+
+  componentWillUnmount() {
+    this.props.dispatch(setStream(this.state.original));
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export default UpDownVoteOrderFilter;

--- a/src/components/stream/index.jsx
+++ b/src/components/stream/index.jsx
@@ -2,10 +2,12 @@ import CommentStream from './CommentStream';
 import StreamTabs from './StreamTabs';
 import StaffFilter from './StaffFilter';
 import BlockFilter from './BlockFilter';
+import UpDownVoteOrderFilter from './UpDownVoteOrderFilter';
 
 export default {
   CommentStream,
   StreamTabs,
   StaffFilter,
-  BlockFilter
+  BlockFilter,
+  UpDownVoteOrderFilter
 };

--- a/src/playground/playgroundComments.js
+++ b/src/playground/playgroundComments.js
@@ -7,6 +7,7 @@ const comments = {
     liked: false,
     reactions: ['heart', 'ok_woman'],
     upvotes: 87,
+    downvotes: 10,
     upvoted: false,
     staffPick: true,
     showProfile:true,
@@ -41,6 +42,7 @@ const comments = {
     liked: false,
     reactions: ['heart', 'ok_woman'],
     upvotes: 45,
+    downvotes: 0,
     upvoted: false
   },
   c:{
@@ -51,6 +53,7 @@ const comments = {
     liked: false,
     reactions: ['heart', 'ok_woman'],
     upvotes: 82,
+    downvotes: 22,
     upvoted: false,
     replies: [
       {
@@ -84,6 +87,7 @@ const comments = {
     liked: false,
     reactions: ['heart', 'ok_woman'],
     upvotes: 84,
+    downvotes: 23,
     upvoted: false
   },
   e:{
@@ -94,6 +98,7 @@ const comments = {
     liked: false,
     reactions: ['heart', 'ok_woman'],
     upvotes: 11,
+    downvotes: 5,
     upvoted: false
   },
   f:{
@@ -104,6 +109,7 @@ const comments = {
     liked: false,
     reactions: ['heart', 'ok_woman'],
     upvotes: 14,
+    downvotes: 0,
     upvoted: false
   },
   g:{
@@ -114,6 +120,7 @@ const comments = {
     liked: false,
     reactions: ['heart', 'ok_woman'],
     upvotes: 30,
+    downvotes: 15,
     upvoted: false
   },
   h:{
@@ -124,6 +131,7 @@ const comments = {
     liked: false,
     reactions: ['heart', 'ok_woman'],
     upvotes: 22,
+    downvotes: 0,
     upvoted: false,
     staffPick: true
   }  

--- a/src/playground/playgroundConfig.js
+++ b/src/playground/playgroundConfig.js
@@ -24,13 +24,7 @@ let config = {
       order:0
     }
   ],
-  interactions:[
-    {
-      propTypes:['id','reactions'],
-      component:'Reactions',
-      order:0
-    }
-  ],
+  interactions:[],
   commentMenu:[],
   authorProfile:[]
 };

--- a/src/playground/playgroundConfig.js
+++ b/src/playground/playgroundConfig.js
@@ -8,10 +8,6 @@ let config = {
       propTypes:['content'],
       component:'DefaultComment',
       order: 0
-    },
-    {
-      component:'CommentDivider',
-      order:1000
     }
   ],
   authors:[
@@ -25,6 +21,13 @@ let config = {
     {
       propTypes:['stream','comments'],
       component:'CommentStream',
+      order:0
+    }
+  ],
+  interactions:[
+    {
+      propTypes:['id','reactions'],
+      component:'Reactions',
       order:0
     }
   ],

--- a/src/playground/playgroundOptions.js
+++ b/src/playground/playgroundOptions.js
@@ -62,7 +62,7 @@ const togglerGroups = {
         status: false,
         topic: 'muting',
         pulseTarget: 'commentName',
-        onFunction:[updateComponent('comments', 'CommentMenu',['id'], -10),addComponent('commentMenu','Block',['id','items'],0)],
+        onFunction:[updateComponent('comments', 'CommentMenu',['id'], -10),addComponent('commentMenu','Block',['id','comments'],0)],
         offFunction:[removeComponent('commentMenu','Block'), removeComponent('stream','BlockFilter')]
       }
     }

--- a/src/playground/playgroundOptions.js
+++ b/src/playground/playgroundOptions.js
@@ -161,7 +161,12 @@ const togglerGroups = {
         offLabel: 'Up/Down voting is OFF',
         description: 'Enables up/down voting on comments.',
         status: false,
-        topic: 'upvotes'
+        topic: 'upvotes',
+        onFunction:[
+          addComponent('interactions','UpDownVoting',['id', 'upvotes','downvotes','updownvoted'],20),
+          addComponent('stream','UpDownVoteOrderFilter',['stream','comments'],20)
+        ],
+        offFunction:[removeComponent('interactions','UpDownVoting'),removeComponent('stream','UpDownVoteOrderFilter')]
       }
     }
   },

--- a/src/playground/playgroundOptions.js
+++ b/src/playground/playgroundOptions.js
@@ -143,7 +143,9 @@ const togglerGroups = {
         offLabel: 'Reactions are OFF',
         description: 'Enables Reactions (other than likes) on comments.',
         status: false,
-        topic: 'reactions'
+        topic: 'reactions',
+        onFunction:addComponent('interactions','Reactions',['id','reactions'],0),
+        offFunction:removeComponent('interactions','Reactions')
       },
       'likes': {
         label: 'Likes are ON',

--- a/src/playground/playgroundOptions.js
+++ b/src/playground/playgroundOptions.js
@@ -152,7 +152,9 @@ const togglerGroups = {
         offLabel: 'Likes are OFF',
         description: 'Enables likes on comments, no dislikes, just likes.',
         status: false,
-        topic: 'likes'
+        topic: 'likes',
+        onFunction:addComponent('interactions','LikeButton',['id', 'likes','liked'],10),
+        offFunction:removeComponent('interactions','LikeButton')
       },
       'upvotes': {
         label: 'Up/Down voting is ON',


### PR DESCRIPTION
## What does this PR do?

Adds the following dynamic react components to playground:
- Emoji
- Like button
- Up and down voting

The comments will also reorder based on the number of up and down votes that they have received.
## Notes:

Emojis have only been partially implemented, as was the case in the original playground. Emojis appear, but there is no emoji picker and no way to “second” votes for emojis. I have moved this to a separate issue and will implement if time allows.
