### PR TITLE
Mobile style bugfixes

### DIFF
--- a/css/playground.css
+++ b/css/playground.css
@@ -154,3 +154,8 @@ p, p span {
     0% { background-position: 0 0; }
     100% { background-position: -300px 0; }
 }
+
+
+#plagyround {
+  -webkit-transform: translate3d(0,0,0);
+}

--- a/src/app/Playground.jsx
+++ b/src/app/Playground.jsx
@@ -26,7 +26,7 @@ class Playground extends React.Component {
 
     return (
       <DocumentTitle title="The Coral Project - Comments Lab">
-        <div>
+        <div id='playground'>
 
           <div style={styles.playgroundContainer}>
             <HeaderNav />

--- a/src/components/layout/InfoModal.jsx
+++ b/src/components/layout/InfoModal.jsx
@@ -71,7 +71,9 @@ const defaultStyles = {
   },
   mobileDialog:{
     width:'100%',
-    maxHeight: '100vh'
+    maxHeight: '100vh',
+    overflowY: 'scroll',
+    marginTop: 0
   },
   dialogContent:{
     fontSize:14,


### PR DESCRIPTION
## What does this PR do?

Addresses issues in https://github.com/coralproject/comments-lab/issues/119
## How do I test this PR?
- Load coral playground in a mobile browser
- Info modals should be scrollable so that you can get to the bottom and close them.
- Safari should no longer have buttons appearing above the side menu
## Note

I don’t have a safari mobile device to test. I’m testing with a local simulator, but we should confirm on the real thing.
